### PR TITLE
Fix Appointments-API: Add missing attribute `description`

### DIFF
--- a/SuperSaaS/API/Appointments.py
+++ b/SuperSaaS/API/Appointments.py
@@ -75,7 +75,8 @@ class Appointments(BaseApi):
                 'field_2_r': attributes.get('field_2_r', None),
                 'super_field': attributes.get('super_field', None),
                 'resource_id': attributes.get('resource_id', None),
-                'slot_id': attributes.get('slot_id', None)
+                'slot_id': attributes.get('slot_id', None),
+                'description': attributes.get('description', None)
             }
         }
         params['booking'] = dict(filter(lambda item: item[1] is not None, params['booking'].items()))
@@ -104,7 +105,8 @@ class Appointments(BaseApi):
                 'field_2_r': attributes.get('field_2_r', None),
                 'super_field': attributes.get('super_field', None),
                 'resource_id': attributes.get('resource_id', None),
-                'slot_id': attributes.get('slot_id', None)
+                'slot_id': attributes.get('slot_id', None),
+                'description': attributes.get('description', None)
             }
         }
         params['booking'] = dict(filter(lambda item: item[1] is not None, params['booking'].items()))


### PR DESCRIPTION
### Issue
Some SuperSaaS schedules require filling up the 'description' field when creating a new appointment. This patch allows client to create a schedule with the `description` field specified.

### Fix
Extract the `description` field from the `attributes` param during create and update appointments

### Test

#### Preparation
Configure a schedule with following settings:
<img width="682" alt="image" src="https://user-images.githubusercontent.com/1549211/79036568-ea87d680-7bfb-11ea-8ed3-5da0ab274fae.png">

#### Before Patch:

Creating an apppointment with 'description' included in attributes
```python
attrs = {"start": "2020-04-16 12:00:00", "finish": "2020-04-16 13:30:00", "field_1_r": "test field_1_r", "full_name": "test fullname"}
Client.instnace().appointments.create(schedule_id=schedule_id, user_id=customer_id, attributes=attrs)
# => SuperSaaS.Error.Error: HTTP Request Error (https://www.supersaas.com/api/bookings.json): Unprocessable Entity
```

#### After Patch:
```python
attrs = {"start": "2020-04-16 12:00:00", "finish": "2020-04-16 13:30:00", "field_1_r": "test field_1_r", "full_name": "test fullname"}
Client.instnace().appointments.create(schedule_id=schedule_id, user_id=customer_id, attributes=attrs)
# => https://www.supersaas.com/api/bookings/xxxxx.json (success)
```